### PR TITLE
Add descriptions to ArgumentParser definitions

### DIFF
--- a/fasta/extract_fasta_regions.py
+++ b/fasta/extract_fasta_regions.py
@@ -46,7 +46,7 @@ import biocodeutils
 
 
 def main():
-    parser = argparse.ArgumentParser( description='Put a description of your script here')
+    parser = argparse.ArgumentParser( description='Extract regions from a multi-FASTA file')
 
     ## output file to be written
     parser.add_argument('-f', '--fasta_file', type=str, required=True, help='Path to an input FASTA file' )

--- a/fasta/fasta_size_distribution_plot.py
+++ b/fasta/fasta_size_distribution_plot.py
@@ -43,7 +43,7 @@ def get_legend_labels(label_arg, file_count):
 
 
 def main():
-    parser = argparse.ArgumentParser( description='Put a description of your script here')
+    parser = argparse.ArgumentParser( description='Generate FASTA file(s) size distribution plot')
 
     parser.add_argument('fasta_files', metavar='N', type=str, nargs='+', help='Pass one or more FASTA files')
     parser.add_argument('-o', '--output_file', type=str, required=True, help='Path to an output file to be created' )

--- a/fasta/filter_fasta_by_type.py
+++ b/fasta/filter_fasta_by_type.py
@@ -39,7 +39,7 @@ import biocodeutils
 
 
 def main():
-    parser = argparse.ArgumentParser( description='Put a description of your script here')
+    parser = argparse.ArgumentParser( description='Split multi-FASTA file into separate protein and nucleotide files')
 
     ## output file to be written
     parser.add_argument('-i', '--input', type=str, required=True, help='Path to an input FASTA file' )

--- a/fasta/merge_masked_fasta_files.py
+++ b/fasta/merge_masked_fasta_files.py
@@ -22,7 +22,7 @@ import biocodeutils
 
 
 def main():
-    parser = argparse.ArgumentParser( description='Put a description of your script here')
+    parser = argparse.ArgumentParser( description='Merge masked FASTA files')
 
     ## output file to be written
     parser.add_argument('fasta_files', metavar='N', type=str, nargs='+', help='Pass one or more FASTA files')

--- a/fasta/remove_duplicate_sequences.py
+++ b/fasta/remove_duplicate_sequences.py
@@ -28,7 +28,7 @@ import hashlib
 
 
 def main():
-    parser = argparse.ArgumentParser( description='Put a description of your script here')
+    parser = argparse.ArgumentParser( description='Read a multi-FASTA file sequence and remove duplicates (by MD5 hash)')
 
     ## output file to be written
     parser.add_argument('-i', '--fasta_file', type=str, required=True, help='Path to an input FASTA file' )

--- a/fasta/split_fasta_into_even_files.py
+++ b/fasta/split_fasta_into_even_files.py
@@ -25,7 +25,7 @@ import os
 import sys
 
 def main():
-    parser = argparse.ArgumentParser( description='Put a description of your script here')
+    parser = argparse.ArgumentParser( description='Split a large FASTA file into new evenly sized files')
 
     ## output file to be written
     parser.add_argument('-i', '--input_file', type=str, required=True, help='Path to an input FASTA file to be read' )

--- a/fastq/convert_fastq_to_fasta.py
+++ b/fastq/convert_fastq_to_fasta.py
@@ -55,7 +55,7 @@ import re
 import sys
 
 def main():
-    parser = argparse.ArgumentParser( description='Put a description of your script here')
+    parser = argparse.ArgumentParser( description='Convert FASTQ to FASTA format')
 
     ## output file to be written
     parser.add_argument('-i', '--input_file', type=str, required=True, help='Path to an input file to be read' )

--- a/fastq/filter_fastq_by_N_content.py
+++ b/fastq/filter_fastq_by_N_content.py
@@ -16,7 +16,7 @@ import re
 import sys
 
 def main():
-    parser = argparse.ArgumentParser( description='Put a description of your script here')
+    parser = argparse.ArgumentParser( description='Filter FASTQ file by N content')
 
     ## output file to be written
     parser.add_argument('-l', '--left', type=str, required=False, help='FASTQ: Left (R1) mate pair file' )

--- a/fastq/interleave_fastq.py
+++ b/fastq/interleave_fastq.py
@@ -9,7 +9,7 @@ import gzip
 import argparse
 
 def interface():
-	args = argparse.ArgumentParser()
+	args = argparse.ArgumentParser(description="Interleave two FASTQ files")
 	args.add_argument('-l', '--left-input',
 		help='The first input file in fastq format.')
 

--- a/gff/compare_gene_structures.py
+++ b/gff/compare_gene_structures.py
@@ -103,7 +103,7 @@ import sys
 
 
 def interface():
-    parser = argparse.ArgumentParser( description='Put a description of your script here')
+    parser = argparse.ArgumentParser( description='Compare two GFF3 files and generate PPV and SN')
     parser.add_argument('-a1', '--annotation_1',type=str, required=True,
 		      help='The first annotation file.')
     parser.add_argument('-a2', '--annotation_2',type=str, required=False,

--- a/gff/convert_augustus_to_gff3.py
+++ b/gff/convert_augustus_to_gff3.py
@@ -60,7 +60,7 @@ FO082871        AUGUSTUS        transcription_end_site  18816   18816   .       
 '''
 
 def main():
-    parser = argparse.ArgumentParser( description='Put a description of your script here')
+    parser = argparse.ArgumentParser( description='Convert native (GTF) or GFF output from Augustus into GFF3 format')
 
     ## output file to be written
     parser.add_argument('-i', '--input', type=str, required=True, help='Path to a GFF file created by Augustus' )

--- a/gff/convert_genbank_to_gff3.py
+++ b/gff/convert_genbank_to_gff3.py
@@ -27,7 +27,7 @@ import biocodegff
 import biocodeutils
 
 def main():
-    parser = argparse.ArgumentParser( description='Put a description of your script here')
+    parser = argparse.ArgumentParser( description='Convert GenBank flat files to GFF3 format')
 
     ## output file to be written
     parser.add_argument('-i', '--input_file', type=str, required=True, help='Path to an input GBK file' )

--- a/gff/convert_pasa_gff_to_models.py
+++ b/gff/convert_pasa_gff_to_models.py
@@ -45,7 +45,7 @@ import biocodegff
 
 
 def main():
-    parser = argparse.ArgumentParser( description='Put a description of your script here')
+    parser = argparse.ArgumentParser( description='Convert PASA GFF file to canonical gene models')
 
     ## output file to be written
     parser.add_argument('-i', '--input', type=str, required=True, help='Path to a GFF file created by PASA' )

--- a/gff/set_source_column.py
+++ b/gff/set_source_column.py
@@ -11,7 +11,7 @@ import sys
 
 
 def main():
-    parser = argparse.ArgumentParser( description='Put a description of your script here')
+    parser = argparse.ArgumentParser( description='Overwrite source (2nd) column in GFF3 file')
 
     ## output file to be written
     parser.add_argument('-i', '--input_file', type=str, required=True, help='Path to an input file to be read' )


### PR DESCRIPTION
A number of the scripts had 'Put a description of your script here' as the description text. This has been replaced with as good as a description as I could manage.