### PR TITLE
Bug fix duplicated genes when converting Genbank into GFF.

### DIFF
--- a/gff/convert_genbank_to_gff3.py
+++ b/gff/convert_genbank_to_gff3.py
@@ -211,9 +211,9 @@ def main():
                 print("WARNING: The following feature was skipped:\n{0}".format(feat))
                 features_skipped_count += 1
 
-        # don't forget to do the last gene, if there were any
-        if current_gene is not None:
-            gene.print_as(fh=ofh, source='GenBank', format='gff3')
+    # don't forget to do the last gene, if there were any
+    if current_gene is not None:
+        gene.print_as(fh=ofh, source='GenBank', format='gff3')
 
     if args.fasta is True:
         if seqs_pending_writes is True:


### PR DESCRIPTION
Greetings Joshua,

I try the script that converts a GenBank into a GFF. In the GFF created, some lines are duplicated. For example, a gene is described in four lines (gene, mRNA, CDS, exon) but these four lines are duplicated three times in the output file.

It seems that this come from the condition which prints the last gene. Indeed this condition is in the for loop but to have only the last gene, it needs to be outside the loop. Otherwise the last gene of each chromosome/scaffold in the GenBank file will be considered as the last gene of the genome and it will be duplicated.

In this commit the indentation is modified and it seems to work; now in the example there are only four lines for the gene and no more duplicated lines are found.
