### PR TITLE
Update convert_tRNAScanSE_to_gff3.pl

### DIFF
--- a/gff/convert_tRNAScanSE_to_gff3.pl
+++ b/gff/convert_tRNAScanSE_to_gff3.pl
@@ -95,6 +95,7 @@ my $i=1;
 
 ## parse the file
 foreach my $line (<$ifh>){
+        $line =~ s/ +//g;
 	my @cols = split /[\t]/, $line;
 	chomp @cols;
 	my $contig = $cols[0];


### PR DESCRIPTION
Bedtools v2.29.2 did not recognize this gff3. Using `cat -t` showed that there are some white spaces just after a coordinate and the tab. Adding this line allowed resulted in a gff3 successfully  processed by bedtools. However, I'm not sure if removing all white spaces could have secondary effects (e.g. for contig names that do contain white spaces).