### PR TITLE
remove the obsolete TODO comment

### DIFF
--- a/build/make_pypi_release.py
+++ b/build/make_pypi_release.py
@@ -115,7 +115,6 @@ def create_script_index_json(script_base, data_dir):
                 if m:
                     desc = m.group(1)
 
-            # TODO: Parse description lines from within each script
             json_data[category].append({'name': script, 'desc': desc})
 
     # Don't change the path of this JSON file without also changing it in the general/list_biocode utility


### PR DESCRIPTION
##### SUMMARY
Remove the obsolete TODO comment. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
build/make_pypi_release.py (line:118)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The pending task of the TODO comment has already performed in the earlier version, but the TODO comment was not removed accordingly at the moment. Please check the following commit: https://github.com/jorvis/biocode/commit/e79fad63c47240e33d9476c9d15522b389d30ad1